### PR TITLE
Fix for Warning: Could not find file

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -12,7 +12,7 @@ client_scripts {
 }
 
 files {
-    'starter_shells_k4mb1.ytyp'
+    'stream/starter_shells_k4mb1.ytyp'
 }
 
 data_file 'DLC_ITYP_REQUEST' 'starter_shells_k4mb1.ytyp'


### PR DESCRIPTION
This fixes the console warning being thrown when starting the script.
