### PR TITLE
Changed Model for Garage Shell

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -140,9 +140,9 @@ exports('CreateFranklinAunt', function(spawn)
     return CreateShell(spawn, exit, model)
 end)
 
-exports('CreateGarageMed', function(spawn)
+exports('CreateMed', function(spawn)
     local exit = json.decode('{"x": 13.90, "y": 1.63, "z": 1.0, "h": 87.05}')
-    local model = 'shell_garagemed'
+    local model = 'shell_garagem'
     return CreateShell(spawn, exit, model)
 end)
 


### PR DESCRIPTION
Wrong model causes infinite loading screen changed to the correct model which is: shell_garagem instead of shell_garagemed

**Describe Pull request**

If your PR is to fix an issue mention that issue here: The wrong model causes a infinite loading screen. To fix this I have ammended to code to the correct shell garage model

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
